### PR TITLE
Remove custom titlebar background color from Windows config

### DIFF
--- a/windows/wezterm.lua
+++ b/windows/wezterm.lua
@@ -6,12 +6,6 @@ return {
   window_decorations = "TITLE | RESIZE",
   window_padding = { left = 0, right = 0, top = 0, bottom = 0 },
 
-  -- Make title bar visually subtle
-  colors = {
-    titlebar_background = "#000000"
-  },
-
-
   -- Default to openSUSE Tumbleweed under WSL.
   default_domain = "WSL:openSUSE-Tumbleweed",
 


### PR DESCRIPTION
## Summary
Removed the custom titlebar background color configuration from the Windows WezTerm settings, reverting to the default appearance.

## Changes
- Removed the `colors` configuration block that set `titlebar_background` to black (`#000000`)
- This allows WezTerm to use its default titlebar styling instead of the previously customized subtle dark appearance

## Details
The titlebar color customization has been removed entirely, simplifying the configuration and allowing the application to use platform defaults or theme-based styling for the title bar.

https://claude.ai/code/session_01CKVfHMQnAY3yFJgfxzMBdy